### PR TITLE
[#20] Allow for longer routine names in code coverage report

### DIFF
--- a/Routines/_ut1.m
+++ b/Routines/_ut1.m
@@ -7,6 +7,7 @@
 	; Major contributions by Dr. Sam Habiel
 	; Additions and modifications made by Joel L. Ivey 05/2014-12/2015
 	; Additions and modifications made by Sam H. Habiel and Joel L. Ivey 12/2015-02/2017
+	; Modified by Christopher Edwards 08/2019
 	;
 	; older comments moved to %utcover due to space requirements
 	;
@@ -382,7 +383,7 @@ COVRPTLS(C,S,R,V)	;
 	F  S RTN=$O(@C@(RTN)) Q:RTN=""  D
 	. N O S O=$$ACTLINES($NA(@C@(RTN)),"RTN")
 	. N L S L=$$ACTLINES($NA(@S@(RTN)),"RTN")
-	. N XX,XY S XX="  "_RTN_"                    ",XX=$E(XX,1,12)
+	. N XX,XY S XX="  "_RTN_"                    ",XX=$E(XX,1,20)
 	. S XY="        "_$S(O:$J((O-L)/O*100,"",2)_"%",1:"------"),XY=$E(XY,$L(XY)-11,$L(XY))
 	. I O>0 S LINNUM=LINNUM+1,@R@(LINNUM)=XX_XY_"  "_(O-L)_" out of "_O
 	. I V=1 QUIT  ; Just print the routine coverage for V=1

--- a/Routines/_uttcovr.m
+++ b/Routines/_uttcovr.m
@@ -3,6 +3,7 @@
 	; Submitted to OSEHRA Jul 8, 2017 by Joel L. Ivey under the Apache 2 license (http://www.apache.org/licenses/LICENSE-2.0.html)
 	; Original routine authored by Joel L. Ivey 05/2014-12/2015
 	; Modified by Joel L. Ivey 02/2016-03/2016
+	; Modified by Christopher Edwards 08/2019
 	;
 	;
 	; ZEXCEPT: DTIME - if present the value is Kernel timeout for reads
@@ -102,7 +103,7 @@ COVRPT	 ; @TEST
 	S VRBOSITY=1
 	D COVRPT^%ut1(GL1,GL2,GL3,VRBOSITY)
 	D CHKEQ("COVERAGE PERCENTAGE: 42.11",$G(@GL3@(5)),"Verbosity 1 - not expected percentage value")
-	D CHKEQ("  %ut1            42.11%  8 out of 19",$G(@GL3@(9)),"Verbosity 1 - not expected value for line 9")
+	D CHKEQ("  %ut1                    42.11%  8 out of 19",$G(@GL3@(9)),"Verbosity 1 - not expected value for line 9")
 	D CHKTF('$D(@GL3@(10)),"Verbosity 1 - unexpected data in 10th line")
 	;
 	S VRBOSITY=2
@@ -130,7 +131,7 @@ COVRPTLS	; @TEST - coverage report returning text in global
 	S VRBOSITY=1
 	D COVRPTLS^%ut1(GL1,GL2,GL3,VRBOSITY)
 	D CHKEQ("COVERAGE PERCENTAGE: 42.11",$G(@GL3@(5)),"Verbosity 1 - not expected percentage value")
-	D CHKEQ("  %ut1            42.11%  8 out of 19",$G(@GL3@(9)),"Verbosity 1 - not expected value for line 9")
+	D CHKEQ("  %ut1                    42.11%  8 out of 19",$G(@GL3@(9)),"Verbosity 1 - not expected value for line 9")
 	D CHKTF('$D(@GL3@(10)),"Verbosity 1 - unexpected data in 10th line")
 	K @GL3
 	;


### PR DESCRIPTION
Increase length of routine name to 20 characters instead of 12
characters

Update unit tests for longer routine names

Fixes #20 