### PR TITLE
Misc tiny fixes

### DIFF
--- a/Routines/_ut.m
+++ b/Routines/_ut.m
@@ -1,4 +1,4 @@
-%ut ;VEN-SMH/JLI - PRIMARY PROGRAM FOR M-UNIT TESTING ;07/05/17  11:47
+%ut ;VEN-SMH/JLI - PRIMARY PROGRAM FOR M-UNIT TESTING ;2019-08-29  4:29 PM
  ;;1.6;M-UNIT;;Aug 28, 2019;Build 6
  ; Submitted to OSEHRA Jul 8, 2017 by Joel L. Ivey under the Apache 2 license (http://www.apache.org/licenses/LICENSE-2.0.html)
  ; Original routine authored by Joel L. Ivey as XTMUNIT while working for U.S. Department of Veterans Affairs 2003-2012
@@ -18,7 +18,7 @@
  D ^%utt6 ; runs unit tests on all of it
  Q
  ;
-en(%utRNAM,%utVERB,%utBREAK)
+en(%utRNAM,%utVERB,%utBREAK) ; Rename of EN
  D EN($G(%utRNAM),$G(%utVERB),$G(%utBREAK))
  QUIT
 EN(%utRNAM,%utVERB,%utBREAK) ; .SR Entry point with primary test routine name
@@ -246,14 +246,14 @@ CHKEQ(XTEXPECT,XTACTUAL,XTERMSG) ; Entry point for checking values to see if the
  I $D(%utGUI),XTEXPECT'=XTACTUAL S %ut("CNT")=%ut("CNT")+1,@%ut("RSLT")@(%ut("CNT"))=%ut("LOC")_XTGUISEP_"FAILURE"_XTGUISEP_FAILMSG_XTERMSG,%ut("FAIL")=%ut("FAIL")+1
  Q
  ;
-fail(XTERMSG)
+fail(XTERMSG) ; Rename of FAIL
  D FAIL($G(XTERMSG))
  QUIT
 FAIL(XTERMSG) ; Entry point for generating a failure message
  D FAIL^%ut1($G(XTERMSG))
  Q
  ;
-succeed
+succeed ; Rename of SUCCEED
  D SUCCEED
  QUIT
 SUCCEED ; Entry point for forcing a success (Thx David Whitten)

--- a/Routines/_utt4.m
+++ b/Routines/_utt4.m
@@ -1,4 +1,4 @@
-%utt4 ; VEN/SMH/JLI - Coverage Test Runner;01/30/17  11:46
+%utt4 ; VEN/SMH/JLI - Coverage Test Runner;2019-08-29  4:27 PM
  ;;1.6;M-UNIT;;Aug 28, 2019;Build 6
  ; Submitted to OSEHRA Jul 8, 2017 by Joel L. Ivey under the Apache 2 license (http://www.apache.org/licenses/LICENSE-2.0.html)
  ; Original routine authored by Sam H. Habiel 07/2013-04/2014
@@ -8,7 +8,7 @@ XTMUNITW ; VEN/SMH - Coverage Test Runner;2014-04-17  3:30 PM
  ;;7.3;KERNEL TOOLKIT;;
  ;
  ; This tests code in XTMUNITV for coverage
- D EN^%ut($T(+0),1)
+ D en^%ut($T(+0),1)
  QUIT
  ;
 MAIN ; @TEST - Test coverage calculations

--- a/Routines/_uttcovr.m
+++ b/Routines/_uttcovr.m
@@ -1,4 +1,4 @@
-%uttcovr ;JIVEYSOFT/JLI - runs coverage tests on %ut and %ut1 routines via unit tests ;06/16/17  15:37
+%uttcovr ;JIVEYSOFT/JLI - runs coverage tests on %ut and %ut1 routines via unit tests ;2019-08-29  4:28 PM
  ;;1.6;M-UNIT;;Aug 28, 2019;Build 6
  ; Submitted to OSEHRA Jul 8, 2017 by Joel L. Ivey under the Apache 2 license (http://www.apache.org/licenses/LICENSE-2.0.html)
  ; Original routine authored by Joel L. Ivey 05/2014-12/2015
@@ -10,10 +10,10 @@
  N RUNCODE,XCLUDE
  ;
  ; Have it run the following entry points or, if no ^, call EN^%ut with routine name
- S RUNCODE(1)="^%utt1,^%utt1,VERBOSE^%utt1(3),^%utt6,VERBOSE^%utt6,VERBOSE3^%utt6,VERBOSE2^%utt6,%uttcovr,^%ut,^%ut1,^%utcover"
+ S RUNCODE(1)="^%utt1,^%utt1,VERBOSE^%utt1(3),^%utt6,VERBOSE^%utt6,VERBOSE3^%utt6,VERBOSE2^%utt6,%uttcovr,^%ut,^%ut1,^%utcover,^%utt7"
  S RUNCODE("ENTRY^%uttcovr")=""
  ; Have the analysis EXCLUDE the following routines from coverage - unit test routines
- S XCLUDE(1)="%utt1,%utt2,%utt3,%utt4,%utt5,%utt6,%uttcovr"
+ S XCLUDE(1)="%utt1,%utt2,%utt3,%utt4,%utt5,%utt6,%utt7,%uttcovr"
  S XCLUDE(2)="%utf2hex" ; a GT.M system file, although it wasn't showing up anyway
  M ^TMP("%uttcovr",$J,"XCLUDE")=XCLUDE
  D COVERAGE^%ut("%ut*",.RUNCODE,.XCLUDE,3)


### PR DESCRIPTION
- Add comments to new entry points w/o comments in %ut
- Test en^%ut (rather than EN^%ut) in ^%utt4
- Include %utt7 in testing, which was in a previous version of the code.