### PR TITLE
Fix !TEST syntax to work when last test is not in list of selected tests

### DIFF
--- a/Routines/_ut1.m
+++ b/Routines/_ut1.m
@@ -38,7 +38,7 @@ CHEKTEST(%utROU,%ut,%utUETRY,FLAG) ; Collect Test list.
  S I=$L($T(@(U_%utROU))) I I<0 Q "-1^Invalid Routine Name"
  D NEWSTYLE(.LIST,%utROU)
  I FLAG D
- . F I=1:1:LIST Q:'$D(LIST(I))  Q:LIST'>0  I $P(LIST(I),U)'="!" S LIST=LIST-1,I=I-1 F J=I+1:1:LIST S LIST(J)=LIST(J+1) I J=LIST K LIST(J+1)
+ . F I=1:1:LIST Q:'$D(LIST(I))  Q:LIST'>0  I $P(LIST(I),U)'="!" S LIST=LIST-1,I=I-1 Q:I=LIST  F J=I+1:1:LIST S LIST(J)=LIST(J+1) I J=LIST K LIST(J+1)
  . F I=LIST+1:1 Q:'$D(LIST(I))  K LIST(I)
  . Q
  F I=1:1:LIST S %ut("ENTN")=%ut("ENTN")+1,%utUETRY(%ut("ENTN"))=$P(LIST(I),U,2),%utUETRY(%ut("ENTN"),"NAME")=$P(LIST(I),U,3,99)


### PR DESCRIPTION
* Below is a simple example where I want to run just `test1` and skip `test2` but
  the tool ends up running both `test1` and `test2`.

  ```m
  $ cat x.m
  x ;
   do en^%ut($t(+0),3)
   quit
  test1 ; !TEST 1
   quit
  test2 ; @TEST 2
   quit
  ```

* This turns out to be a subtle issue in `for` loop that examines all test tags for `!TEST`
  and prunes/kills all `@TEST` entries surrounding it.

  In the `FOR` loop, `I` keeps on increasing from 1 up to `LIST`. `LIST` variable is initially
  set to indicate the total number of tests. And keeps decreasing we prune out entries.
  At some point `I` and `LIST` meet each other and at that point, the pruning does not do the
  right thing. This is fixed by checking for equality and quitting out of the loop right away.

  The immediately following (and pre-existing) `FOR` loop already takes care of the appropriate
  cleanup in this case.

* Note that if the last test has the `!TEST` tag, then the existing logic works fine. It is only
  if the last test does not have the `!TEST` tag and some other tests have the `!TEST` tag that
  this issue arises.